### PR TITLE
feat: Dynamic OG image for earthquake detail pages

### DIFF
--- a/src/app/(main)/sismos/detalle/[id]/page.tsx
+++ b/src/app/(main)/sismos/detalle/[id]/page.tsx
@@ -34,18 +34,31 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const title = `Sismo de magnitud ${earthquake.magnitude} en ${location}`;
   const description = `Sismo registrado el ${earthquake.date} a las ${earthquake.time} con magnitud ${earthquake.magnitude} en ${location}. ${earthquake.details || ''}`;
 
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://sismosmx.app';
+  const ogImageUrl = `${siteUrl}/api/og/earthquake/${id}`;
+  const ogTitle = `Sismo M${earthquake.magnitude} en ${location}`;
+
   return {
     title,
     description,
     openGraph: {
-      title: `${title} | Sismos México`,
+      title: `${ogTitle} | Sismos México`,
       description,
       type: 'article',
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: `Mapa del sismo de magnitud ${earthquake.magnitude} en ${location}`,
+        },
+      ],
     },
     twitter: {
-      card: 'summary',
-      title,
+      card: 'summary_large_image',
+      title: ogTitle,
       description,
+      images: [ogImageUrl],
     },
     alternates: {
       canonical: `/sismos/detalle/${id}`,

--- a/src/app/api/og/earthquake/[token]/route.tsx
+++ b/src/app/api/og/earthquake/[token]/route.tsx
@@ -1,0 +1,195 @@
+/* eslint-disable @next/next/no-img-element */
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+
+const DATA_API_URL = process.env.DATA_API_URL!;
+const DATA_API_KEY = process.env.DATA_API_KEY!;
+const MAPBOX_ACCESS_TOKEN = process.env.MAPBOX_ACCESS_TOKEN!;
+
+function getMagnitudeColor(magnitude: number): string {
+  if (magnitude >= 6.0) return '#dc2626';
+  if (magnitude >= 5.0) return '#ea580c';
+  if (magnitude >= 4.0) return '#f59e0b';
+  return '#22c55e';
+}
+
+function parseLocation(detalles: string): { town: string; state: string } {
+  const parts = detalles?.split('de')[1]?.split(',');
+  return {
+    town: parts?.length > 0 ? parts[0].trim() : '',
+    state: parts?.length > 1 ? parts[1].trim() : '',
+  };
+}
+
+function formatDate(fecha: string): { date: string; time: string } {
+  const dt = new Date(fecha);
+  const date = dt.toLocaleDateString('es-MX', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+  let hours = dt.getHours();
+  let minutes: number | string = dt.getMinutes();
+  const ampm = hours >= 12 ? 'pm' : 'am';
+  hours %= 12;
+  hours = hours || 12;
+  minutes = minutes < 10 ? `0${minutes}` : minutes;
+  return { date, time: `${hours}:${minutes} ${ampm}` };
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+
+  let earthquake: {
+    magnitud: number;
+    laltitud: string;
+    longitud: string;
+    detalles: string;
+    fecha: string;
+  } | null = null;
+
+  try {
+    const res = await fetch(`${DATA_API_URL}/api/sismos/info/detail/${token}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-ApiKey': DATA_API_KEY,
+      },
+    });
+    earthquake = await res.json();
+  } catch {
+    // Fall through to fallback
+  }
+
+  if (!earthquake || !earthquake.laltitud || !earthquake.longitud) {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#1a1a2e',
+            fontFamily: 'sans-serif',
+            color: 'white',
+          }}
+        >
+          <span style={{ fontSize: 64, fontWeight: 800 }}>Sismos México</span>
+          <span style={{ fontSize: 28, color: '#a0a0b0', marginTop: 16 }}>
+            sismosmx.app
+          </span>
+        </div>
+      ),
+      { width: 1200, height: 630 },
+    );
+  }
+
+  const magnitude = typeof earthquake.magnitud === 'string'
+    ? parseFloat(earthquake.magnitud)
+    : earthquake.magnitud;
+  const lat = parseFloat(earthquake.laltitud);
+  const lng = parseFloat(earthquake.longitud);
+  const { town, state } = parseLocation(earthquake.detalles);
+  const { date, time } = formatDate(earthquake.fecha);
+
+  const location = town ? `${town}, ${state}` : state || 'México';
+
+  const mapUrl = `https://api.mapbox.com/styles/v1/mapbox/dark-v11/static/pin-l+ef4444(${lng},${lat})/${lng},${lat},6,0/1200x400@2x?access_token=${MAPBOX_ACCESS_TOKEN}&logo=false&attribution=false`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#1a1a2e',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <img
+          src={mapUrl}
+          width={1200}
+          height={400}
+          alt="map"
+          style={{ objectFit: 'cover' }}
+        />
+
+        <div
+          style={{
+            display: 'flex',
+            flex: 1,
+            padding: '24px 40px',
+            alignItems: 'center',
+            gap: 32,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 120,
+              height: 120,
+              borderRadius: 60,
+              backgroundColor: getMagnitudeColor(magnitude),
+            }}
+          >
+            <span style={{ fontSize: 48, fontWeight: 800, color: 'white' }}>
+              {magnitude.toFixed(1)}
+            </span>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+            <span
+              style={{
+                fontSize: 36,
+                fontWeight: 700,
+                color: 'white',
+                lineClamp: 2,
+              }}
+            >
+              {location}
+            </span>
+            <span style={{ fontSize: 24, color: '#a0a0b0', marginTop: 8 }}>
+              {date}
+              {' '}
+              •
+              {' '}
+              {time}
+            </span>
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <span style={{ fontSize: 18, color: '#a0a0b0' }}>
+              Sismos México
+            </span>
+            <span style={{ fontSize: 14, color: '#7c3aed', marginTop: 4 }}>
+              sismosmx.app
+            </span>
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      headers: {
+        'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- **New endpoint** `/api/og/earthquake/[token]` — generates dynamic 1200×630 OG images using `ImageResponse` (satori) on edge runtime
- **Mapbox Static API** dark-v11 map with red pin at epicenter, magnitude badge with color scale, location, date/time, and branding
- **Updated metadata** in detail page: dynamic `og:image` + `summary_large_image` twitter card (was `summary`)
- **CDN cached** 24h with stale-while-revalidate 7 days — images generated on-demand only when shared
- **Fallback** generic branded image when earthquake data is unavailable

## Visual layout
```
┌──────────────────────────────────────────────┐
│         [Mapbox dark map + red pin]          │
├──────────────────────────────────────────────┤
│  ┌─────┐                                    │
│  │ 4.5 │  Oaxaca de Juárez, Oaxaca          │
│  └─────┘  7 de marzo de 2026 • 2:32 pm      │
│                              Sismos México   │
└──────────────────────────────────────────────┘
```

## Environment variable required
Add `MAPBOX_ACCESS_TOKEN` to Vercel environment variables before deploying.

## Related
- RFC-031: Share-to-Download SEO Strategy
- PR #181 (earthquakes_flutter): Flutter contextual share text (Phase 2)

## Test plan
- [ ] Add `MAPBOX_ACCESS_TOKEN` to Vercel env vars
- [ ] Deploy to preview and visit `/api/og/earthquake/{valid-token}` — verify image renders with map, magnitude, location
- [ ] Visit `/api/og/earthquake/invalid-token` — verify fallback image renders
- [ ] Share a detail page URL on WhatsApp/Twitter — verify rich preview with large image
- [ ] Validate with https://opengraph.xyz or Twitter Card Validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)