### PR TITLE
feat: Optimize earthquake detail landing page for conversions

### DIFF
--- a/src/app/(main)/sismos/detalle/[id]/page.tsx
+++ b/src/app/(main)/sismos/detalle/[id]/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from 'next';
 import {
-  HomeHeroSection,
+  EarthquakeHeroSection,
   EarthquakesSection,
   SeeMoreSection,
   DownloadSection,
 } from '@/components/sections';
+import { StickyDownloadBar } from '@/components/widgets';
 import { BreadcrumbJsonLd, EarthquakeEventJsonLd } from '@/components/seo';
 import { getEarthquakeDetail, parseEarthquakes } from '@/services';
 
@@ -89,8 +90,11 @@ export default async function EarthquakeDetailPage({ params }: Props) {
         />
       )}
       <main>
-        <HomeHeroSection />
+        {earthquake ? (
+          <EarthquakeHeroSection earthquake={earthquake} />
+        ) : null}
         <EarthquakesSection earthquakes={detail} />
+        <DownloadSection />
         <SeeMoreSection
           title="¿Quieres enterarte de más sismos?"
           button={{
@@ -98,7 +102,7 @@ export default async function EarthquakeDetailPage({ params }: Props) {
             href: '/sismos',
           }}
         />
-        <DownloadSection />
+        <StickyDownloadBar />
       </main>
     </>
   );

--- a/src/components/sections/earthquake-hero-section/EarthquakeHeroSection.tsx
+++ b/src/components/sections/earthquake-hero-section/EarthquakeHeroSection.tsx
@@ -1,0 +1,67 @@
+import { EarthquakeProps, AppDownloadButton } from '@/components/widgets';
+
+function getMagnitudeColor(magnitude: number): string {
+  if (magnitude >= 6.0) return 'bg-red-600';
+  if (magnitude >= 5.0) return 'bg-orange-500';
+  if (magnitude >= 4.0) return 'bg-amber-500';
+  return 'bg-green-500';
+}
+
+interface EarthquakeHeroSectionProps {
+  earthquake: EarthquakeProps;
+}
+
+export function EarthquakeHeroSection({ earthquake }: EarthquakeHeroSectionProps) {
+  const location = earthquake.town
+    ? `${earthquake.town}, ${earthquake.state}`
+    : earthquake.state || 'México';
+
+  return (
+    <section className="bg-brand py-8 text-white md:py-12">
+      <div className="container mx-auto flex flex-col items-center gap-6 px-4 text-center">
+        <div className="flex items-center gap-4">
+          <div
+            className={`flex size-16 items-center justify-center rounded-full md:size-20 ${getMagnitudeColor(earthquake.magnitude)}`}
+          >
+            <span className="text-2xl font-extrabold md:text-3xl">
+              {earthquake.magnitude.toFixed(1)}
+            </span>
+          </div>
+          <div className="text-left">
+            <h1 className="text-xl font-bold md:text-3xl">
+              Sismo en
+              {' '}
+              {location.trim()}
+            </h1>
+            <p className="text-sm text-white/70 md:text-base">
+              {earthquake.date}
+              {' '}
+              •
+              {' '}
+              {earthquake.time}
+            </p>
+          </div>
+        </div>
+
+        <p className="max-w-lg text-sm text-white/80 md:text-base">
+          Recibe alertas de sismos en tiempo real directamente en tu celular
+        </p>
+
+        <div className="flex gap-4">
+          <AppDownloadButton
+            href={process.env.NEXT_PUBLIC_ANDROID_APP_URL as string}
+            label="Android"
+            target="_blank"
+            className="bg-white text-brand hover:bg-white/90"
+          />
+          <AppDownloadButton
+            href={process.env.NEXT_PUBLIC_IOS_APP_URL as string}
+            label="Apple Store"
+            target="_blank"
+            className="bg-white text-brand hover:bg-white/90"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -8,3 +8,4 @@ export * from './legal-notice-section/LegalNoticeSection';
 export * from './legal-notice-section/content';
 export * from './ritcher-scale-section/RitcherScaleSection';
 export * from './earthquakes-section/EarthquakesSection';
+export * from './earthquake-hero-section/EarthquakeHeroSection';

--- a/src/components/widgets/index.ts
+++ b/src/components/widgets/index.ts
@@ -12,3 +12,4 @@ export * from './earthquakes-table/factory/EarthquakesTableFactory';
 export * from './earthquakes-table/factory/model';
 export * from './earthquake-card/EarthquakeCard';
 export * from './smart-app-banner/SmartAppBanner';
+export * from './sticky-download-bar/StickyDownloadBar';

--- a/src/components/widgets/sticky-download-bar/StickyDownloadBar.tsx
+++ b/src/components/widgets/sticky-download-bar/StickyDownloadBar.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { X } from 'lucide-react';
+
+const STICKY_DISMISSED_KEY = 'sticky-download-dismissed';
+
+export function StickyDownloadBar() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const dismissed = sessionStorage.getItem(STICKY_DISMISSED_KEY);
+    if (!dismissed) setVisible(true);
+  }, []);
+
+  const handleClose = () => {
+    sessionStorage.setItem(STICKY_DISMISSED_KEY, 'true');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  const storeUrl = (process.env.NEXT_PUBLIC_IOS_APP_URL as string)
+    || (process.env.NEXT_PUBLIC_ANDROID_APP_URL as string)
+    || '#';
+
+  return (
+    <div className="fixed bottom-0 left-0 z-50 flex w-full items-center justify-between gap-3 bg-brand px-4 py-3 shadow-lg md:hidden">
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-white">Sismos México</p>
+        <p className="text-xs text-white/70">Alertas de sismos en tiempo real</p>
+      </div>
+
+      <a
+        href={storeUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 rounded-full bg-white px-5 py-2 text-sm font-bold text-brand"
+      >
+        Descargar
+      </a>
+
+      <button
+        type="button"
+        onClick={handleClose}
+        aria-label="Cerrar"
+        className="shrink-0 text-white/70"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **New `EarthquakeHeroSection`** — replaces generic "Sismos de México" hero with contextual earthquake data (magnitude badge with color scale, location, date) + download CTAs visible above the fold
- **New `StickyDownloadBar`** — fixed bottom bar on mobile with "Descargar" CTA (dismissible via sessionStorage)
- **Reordered sections** — `DownloadSection` now appears before `SeeMoreSection` for better conversion funnel

## Before → After layout

```
BEFORE:                          AFTER:
┌─────────────────────┐          ┌─────────────────────┐
│ "Sismos de México"  │ generic  │ M4.1 San Marcos,GRO │ contextual
│                     │ hero     │ [Android] [iOS]     │ hero + CTAs
├─────────────────────┤          ├─────────────────────┤
│ Earthquake data     │          │ Earthquake data     │
├─────────────────────┤          ├─────────────────────┤
│ "Ver más sismos"    │          │ ¡Descarga la App!   │ moved UP
├─────────────────────┤          ├─────────────────────┤
│ ¡Descarga la App!   │ buried   │ "Ver más sismos"    │
└─────────────────────┘          ├─────────────────────┤
                                 │ [Sticky: Descargar] │ mobile only
                                 └─────────────────────┘
```

## Related
- RFC-031: Share-to-Download SEO Strategy (Phase 3)
- PR #505: Dynamic OG image (Phase 1)
- PR #181 (earthquakes_flutter): Contextual share text (Phase 2)

## Test plan
- [ ] Visit a detail page on desktop — verify hero shows magnitude, location, date, and download buttons
- [ ] Visit on mobile — verify sticky download bar appears at bottom
- [ ] Dismiss sticky bar — verify it doesn't reappear in same session
- [ ] Open a new session — verify sticky bar reappears
- [ ] Verify no earthquake (404 token) — hero section gracefully hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)