### PR TITLE
fix: Detail page UX polish — map, banner, CTA redundancy

### DIFF
--- a/src/app/(main)/sismos/detalle/[id]/page.tsx
+++ b/src/app/(main)/sismos/detalle/[id]/page.tsx
@@ -94,7 +94,6 @@ export default async function EarthquakeDetailPage({ params }: Props) {
           <EarthquakeHeroSection earthquake={earthquake} />
         ) : null}
         <EarthquakesSection earthquakes={detail} mapTitle="Detalle del sismo" />
-        <DownloadSection />
         <SeeMoreSection
           title="¿Quieres enterarte de más sismos?"
           button={{
@@ -102,6 +101,7 @@ export default async function EarthquakeDetailPage({ params }: Props) {
             href: '/sismos',
           }}
         />
+        <DownloadSection />
         <StickyDownloadBar />
       </main>
     </>

--- a/src/app/(main)/sismos/detalle/[id]/page.tsx
+++ b/src/app/(main)/sismos/detalle/[id]/page.tsx
@@ -93,7 +93,7 @@ export default async function EarthquakeDetailPage({ params }: Props) {
         {earthquake ? (
           <EarthquakeHeroSection earthquake={earthquake} />
         ) : null}
-        <EarthquakesSection earthquakes={detail} />
+        <EarthquakesSection earthquakes={detail} mapTitle="Detalle del sismo" />
         <DownloadSection />
         <SeeMoreSection
           title="¿Quieres enterarte de más sismos?"

--- a/src/components/sections/earthquake-hero-section/EarthquakeHeroSection.tsx
+++ b/src/components/sections/earthquake-hero-section/EarthquakeHeroSection.tsx
@@ -1,4 +1,4 @@
-import { EarthquakeProps, AppDownloadButton } from '@/components/widgets';
+import { EarthquakeProps } from '@/components/widgets';
 
 function getMagnitudeColor(magnitude: number): string {
   if (magnitude >= 6.0) return 'bg-red-600';
@@ -17,49 +17,28 @@ export function EarthquakeHeroSection({ earthquake }: EarthquakeHeroSectionProps
     : earthquake.state || 'México';
 
   return (
-    <section className="bg-brand py-8 text-white md:py-12">
-      <div className="container mx-auto flex flex-col items-center gap-6 px-4 text-center">
-        <div className="flex items-center gap-4">
-          <div
-            className={`flex size-16 items-center justify-center rounded-full md:size-20 ${getMagnitudeColor(earthquake.magnitude)}`}
-          >
-            <span className="text-2xl font-extrabold md:text-3xl">
-              {earthquake.magnitude.toFixed(1)}
-            </span>
-          </div>
-          <div className="text-left">
-            <h1 className="text-xl font-bold md:text-3xl">
-              Sismo en
-              {' '}
-              {location.trim()}
-            </h1>
-            <p className="text-sm text-white/70 md:text-base">
-              {earthquake.date}
-              {' '}
-              •
-              {' '}
-              {earthquake.time}
-            </p>
-          </div>
+    <section className="bg-brand py-6 text-white md:py-10">
+      <div className="container mx-auto flex items-center justify-center gap-4 px-4">
+        <div
+          className={`flex size-16 shrink-0 items-center justify-center rounded-full md:size-20 ${getMagnitudeColor(earthquake.magnitude)}`}
+        >
+          <span className="text-2xl font-extrabold md:text-3xl">
+            {earthquake.magnitude.toFixed(1)}
+          </span>
         </div>
-
-        <p className="max-w-lg text-sm text-white/80 md:text-base">
-          Recibe alertas de sismos en tiempo real directamente en tu celular
-        </p>
-
-        <div className="flex gap-4">
-          <AppDownloadButton
-            href={process.env.NEXT_PUBLIC_ANDROID_APP_URL as string}
-            label="Android"
-            target="_blank"
-            className="bg-white text-brand hover:bg-white/90"
-          />
-          <AppDownloadButton
-            href={process.env.NEXT_PUBLIC_IOS_APP_URL as string}
-            label="Apple Store"
-            target="_blank"
-            className="bg-white text-brand hover:bg-white/90"
-          />
+        <div>
+          <h1 className="text-xl font-bold md:text-3xl">
+            Sismo en
+            {' '}
+            {location.trim()}
+          </h1>
+          <p className="text-sm text-white/70 md:text-base">
+            {earthquake.date}
+            {' '}
+            •
+            {' '}
+            {earthquake.time}
+          </p>
         </div>
       </div>
     </section>

--- a/src/components/sections/earthquakes-map-section/EarthquakesMapSection.tsx
+++ b/src/components/sections/earthquakes-map-section/EarthquakesMapSection.tsx
@@ -3,13 +3,17 @@
 import { EarthquakesMap } from '@/features';
 import { useEarthquakesData } from '@/components/providers';
 
-export function EarthquakesMapSection() {
+interface EarthquakesMapSectionProps {
+  title?: string;
+}
+
+export function EarthquakesMapSection({ title = 'Últimos sismos' }: EarthquakesMapSectionProps) {
   const { earthquakes } = useEarthquakesData();
 
   return (
     <section className="mx-auto mt-4 text-center font-semibold md:container md:my-8 md:mt-8 md:text-5xl">
       <hr className="mx-auto hidden h-px max-w-7xl border-foreground md:block" />
-      <h2 className="my-4 text-xl md:my-8 md:mb-8 md:text-5xl">Últimos sismos</h2>
+      <h2 className="my-4 text-xl md:my-8 md:mb-8 md:text-5xl">{title}</h2>
       <EarthquakesMap earthquakes={earthquakes} />
     </section>
   );

--- a/src/components/sections/earthquakes-section/EarthquakesSection.tsx
+++ b/src/components/sections/earthquakes-section/EarthquakesSection.tsx
@@ -6,13 +6,15 @@ import { EarthquakeCardList } from './EarthquakeCardList';
 export function EarthquakesSection({
   paginated = false,
   earthquakes,
+  mapTitle,
 }: {
   paginated?: boolean;
   earthquakes: EarthquakeProps[];
+  mapTitle?: string;
 }) {
   return (
     <EarthquakesDataProvider earthquakes={earthquakes}>
-      <EarthquakesMapSection />
+      <EarthquakesMapSection title={mapTitle} />
       <RitcherScaleSection />
 
       {!paginated && (

--- a/src/components/widgets/smart-app-banner/SmartAppBanner.tsx
+++ b/src/components/widgets/smart-app-banner/SmartAppBanner.tsx
@@ -37,7 +37,7 @@ export function SmartAppBanner() {
       </button>
 
       <Image
-        src="/icon-app.png"
+        src="/logo.svg"
         alt="Sismos México App"
         width={40}
         height={40}

--- a/src/components/widgets/smart-app-banner/SmartAppBanner.tsx
+++ b/src/components/widgets/smart-app-banner/SmartAppBanner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { usePathname } from 'next/navigation';
 import { X } from 'lucide-react';
 import Image from 'next/image';
 
@@ -8,6 +9,8 @@ const BANNER_DISMISSED_KEY = 'smart-app-banner-dismissed';
 
 export function SmartAppBanner() {
   const [visible, setVisible] = useState(false);
+  const pathname = usePathname();
+  const isDetailPage = pathname.startsWith('/sismos/detalle/');
 
   useEffect(() => {
     const dismissed = sessionStorage.getItem(BANNER_DISMISSED_KEY);
@@ -19,7 +22,7 @@ export function SmartAppBanner() {
     setVisible(false);
   };
 
-  if (!visible) return null;
+  if (!visible || isDetailPage) return null;
 
   const storeUrl = (process.env.NEXT_PUBLIC_IOS_APP_URL as string)
     || (process.env.NEXT_PUBLIC_ANDROID_APP_URL as string)

--- a/src/features/earthquakes-map/EarthquakesMap.tsx
+++ b/src/features/earthquakes-map/EarthquakesMap.tsx
@@ -22,8 +22,15 @@ const parseMarkers = (earthquakes: EarthquakeProps[]) => {
 export function EarthquakesMap(props: EarthquakesMapProps) {
   const { earthquakes } = props;
   const { selected } = useEarthquakesData();
-  const [zoom, setZoom] = useState(4.7);
-  const [position, setPosition] = useState(DEFAULT_CENTER);
+
+  const isSingle = earthquakes?.length === 1;
+  const initialCenter = isSingle
+    ? { lat: earthquakes[0].lat, lng: earthquakes[0].lng }
+    : DEFAULT_CENTER;
+  const initialZoom = isSingle ? 8 : 4.7;
+
+  const [zoom, setZoom] = useState(initialZoom);
+  const [position, setPosition] = useState(initialCenter);
   const [markers, setMarkers] = useState(parseMarkers(earthquakes));
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **SmartAppBanner**: fix broken `icon-app.png` → `logo.svg`, hide on detail pages (redundant with StickyDownloadBar)
- **Map title**: configurable via prop — detail page shows "Detalle del sismo" instead of "Últimos sismos"
- **Map centering**: auto-center on epicenter (zoom 8) when viewing single earthquake
- **Hero**: remove download buttons — only earthquake context (magnitude, location, date)
- **CTA cleanup**: 4 CTAs → 2 (DownloadSection + StickyBar), no decision fatigue

## Before → After

```
BEFORE (4 CTAs):                 AFTER (2 CTAs):
┌──────────────────────┐         ┌──────────────────────┐
│ [SmartBanner] "Abrir"│ ← gone  │ NavBar               │
│ Hero + [And] [iOS]   │ ← gone  │ Hero: M4.1 context   │
│ Map (zoomed out)     │         │ Map (centered)       │
│ DownloadSection      │         │ "Ver más sismos"     │
│ [Sticky: Descargar]  │         │ DownloadSection      │ ← CTA 1
└──────────────────────┘         │ [Sticky: Descargar]  │ ← CTA 2
                                 └──────────────────────┘
```

## Test plan
- [ ] Detail page: hero shows magnitude + location only (no download buttons)
- [ ] Detail page: SmartAppBanner hidden, StickyBar visible on mobile
- [ ] Detail page: map centered on epicenter with zoom 8
- [ ] Detail page: heading says "Detalle del sismo"
- [ ] Home page: SmartAppBanner still works, map title still "Últimos sismos"
- [ ] Home page: map still centered on Mexico (DEFAULT_CENTER)

🤖 Generated with [Claude Code](https://claude.com/claude-code)