### PR TITLE
feat: JSON-LD schema fix + statistics page

### DIFF
--- a/src/app/(main)/sismos/estadisticas/page.tsx
+++ b/src/app/(main)/sismos/estadisticas/page.tsx
@@ -1,0 +1,240 @@
+import { Metadata } from 'next';
+import {
+  Activity,
+  TrendingUp,
+  TrendingDown,
+  MapPin,
+  Zap,
+  BarChart3,
+  Calendar,
+} from 'lucide-react';
+import { BreadcrumbJsonLd } from '@/components/seo';
+import { DownloadSection, SeeMoreSection } from '@/components/sections';
+import { getStatistics } from '@/services';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Estadísticas de Sismos en México - Actividad Sísmica',
+  description:
+    'Estadísticas de actividad sísmica en México: total de sismos, magnitud promedio,'
+    + ' distribución por intensidad, estados más activos y tendencias.',
+  openGraph: {
+    title: 'Estadísticas de Sismos en México',
+    description:
+      'Estadísticas de actividad sísmica en México: total de sismos, magnitud promedio, distribución y tendencias.',
+  },
+  alternates: {
+    canonical: '/sismos/estadisticas',
+  },
+};
+
+function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+type StatCardProps = {
+  label: string;
+  value: string | number;
+  icon: React.ReactNode;
+};
+
+function StatCard({ label, value, icon }: StatCardProps) {
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <div className="mb-2 text-muted-foreground">{icon}</div>
+      <p className="text-2xl font-bold">{value}</p>
+      <p className="text-sm text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+type InsightCardProps = {
+  title: string;
+  description: string;
+  type: string;
+};
+
+function InsightCard({ title, description, type }: InsightCardProps) {
+  const iconMap: Record<string, React.ReactNode> = {
+    most_active_state: <MapPin className="size-5 text-red-500" />,
+    activity_trend: <TrendingUp className="size-5 text-blue-500" />,
+    strongest_earthquake: <Zap className="size-5 text-amber-500" />,
+  };
+
+  return (
+    <div className="flex items-start gap-3 rounded-xl border bg-card p-4 shadow-sm">
+      <div className="mt-0.5 shrink-0">{iconMap[type] || <Activity className="size-5" />}</div>
+      <div>
+        <p className="font-semibold">{title}</p>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+type MagnitudeBarProps = {
+  range: string;
+  count: number;
+  max: number;
+};
+
+function MagnitudeBar({ range, count, max }: MagnitudeBarProps) {
+  const percentage = max > 0 ? (count / max) * 100 : 0;
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-12 shrink-0 text-right text-sm font-medium">{range}</span>
+      <div className="h-6 flex-1 overflow-hidden rounded-full bg-muted">
+        <div
+          className="flex h-full items-center rounded-full bg-brand px-2 text-xs font-medium text-white transition-all"
+          style={{ width: `${Math.max(percentage, 8)}%` }}
+        >
+          {count}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default async function StatisticsPage() {
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now);
+  thirtyDaysAgo.setDate(now.getDate() - 30);
+
+  const response = await getStatistics(formatDate(thirtyDaysAgo), formatDate(now));
+  const stats = response?.data;
+  const insights = stats?.insights || [];
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.sismosmx.app';
+  const breadcrumbs = [
+    { name: 'Inicio', url: siteUrl },
+    { name: 'Sismos', url: `${siteUrl}/sismos` },
+    { name: 'Estadísticas', url: `${siteUrl}/sismos/estadisticas` },
+  ];
+
+  const magnitudeDistribution = stats?.magnitudeDistribution || {};
+  const maxDistValue = Math.max(...Object.values(magnitudeDistribution).map(Number), 1);
+
+  const startFormatted = thirtyDaysAgo.toLocaleDateString('es-MX', { day: 'numeric', month: 'short' });
+  const endFormatted = now.toLocaleDateString('es-MX', { day: 'numeric', month: 'short', year: 'numeric' });
+
+  return (
+    <>
+      <BreadcrumbJsonLd items={breadcrumbs} />
+      <main>
+        {/* Hero */}
+        <section className="bg-brand py-8 text-white md:py-12">
+          <div className="container mx-auto px-4 text-center">
+            <h1 className="text-2xl font-bold md:text-4xl">Estadísticas Sísmicas de México</h1>
+            <p className="mt-2 flex items-center justify-center gap-2 text-sm text-white/70 md:text-base">
+              <Calendar className="size-4" />
+              {`${startFormatted} — ${endFormatted}`}
+            </p>
+          </div>
+        </section>
+
+        <div className="container mx-auto max-w-4xl px-4 py-8 md:py-12">
+          {!stats ? (
+            <div className="rounded-xl border bg-card p-8 text-center">
+              <Activity className="mx-auto mb-4 size-12 text-muted-foreground" />
+              <p className="text-lg font-semibold">No se pudieron cargar las estadísticas</p>
+              <p className="text-sm text-muted-foreground">Intenta de nuevo más tarde</p>
+            </div>
+          ) : (
+            <div className="space-y-8">
+              {/* Insights */}
+              {insights.length > 0 && (
+                <section>
+                  <h2 className="mb-4 text-lg font-bold md:text-xl">Datos clave del periodo</h2>
+                  <div className="grid gap-3 md:grid-cols-3">
+                    {insights.map((insight: InsightCardProps) => (
+                      <InsightCard
+                        key={insight.type}
+                        type={insight.type}
+                        title={insight.title}
+                        description={insight.description}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {/* Summary cards */}
+              <section>
+                <h2 className="mb-4 text-lg font-bold md:text-xl">Resumen</h2>
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                  <StatCard
+                    label="Total de sismos"
+                    value={stats.totalCount ?? '—'}
+                    icon={<Activity className="size-5" />}
+                  />
+                  <StatCard
+                    label="Magnitud promedio"
+                    value={stats.averageMagnitude?.toFixed(1) ?? '—'}
+                    icon={<BarChart3 className="size-5" />}
+                  />
+                  <StatCard
+                    label="Magnitud máxima"
+                    value={stats.maxMagnitude?.toFixed(1) ?? '—'}
+                    icon={<TrendingUp className="size-5" />}
+                  />
+                  <StatCard
+                    label="Magnitud mínima"
+                    value={stats.minMagnitude?.toFixed(1) ?? '—'}
+                    icon={<TrendingDown className="size-5" />}
+                  />
+                </div>
+              </section>
+
+              {/* Magnitude distribution */}
+              {Object.keys(magnitudeDistribution).length > 0 && (
+                <section>
+                  <h2 className="mb-4 text-lg font-bold md:text-xl">Distribución por magnitud</h2>
+                  <div className="space-y-2 rounded-xl border bg-card p-4 shadow-sm">
+                    {Object.entries(magnitudeDistribution).map(([range, count]) => (
+                      <MagnitudeBar
+                        key={range}
+                        range={range}
+                        count={Number(count)}
+                        max={maxDistValue}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {/* Monthly count */}
+              {stats.monthlyCount && Object.keys(stats.monthlyCount).length > 0 && (
+                <section>
+                  <h2 className="mb-4 text-lg font-bold md:text-xl">Sismos por mes</h2>
+                  <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                    {Object.entries(stats.monthlyCount).map(([month, count]) => {
+                      const [year, m] = month.split('-');
+                      const d = new Date(Number(year), Number(m) - 1);
+                      const monthName = d.toLocaleDateString('es-MX', {
+                        month: 'short',
+                        year: 'numeric',
+                      });
+                      return (
+                        <div key={month} className="rounded-xl border bg-card p-4 text-center shadow-sm">
+                          <p className="text-2xl font-bold">{String(count)}</p>
+                          <p className="text-sm capitalize text-muted-foreground">{monthName}</p>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+              )}
+            </div>
+          )}
+        </div>
+
+        <SeeMoreSection
+          title="¿Quieres ver los sismos recientes?"
+          button={{ label: 'Listado de sismos', href: '/sismos' }}
+        />
+        <DownloadSection />
+      </main>
+    </>
+  );
+}

--- a/src/app/api/earthquakes/statistics/route.ts
+++ b/src/app/api/earthquakes/statistics/route.ts
@@ -1,0 +1,27 @@
+import { apiGuard, isValidSecret } from '@/utils';
+
+const DATA_API_KEY = process.env.DATA_API_KEY!;
+
+export async function GET(request: Request) {
+  const apiUrl = process.env.DATA_API_URL!;
+
+  const { searchParams } = new URL(request.url);
+  const secret = searchParams.get('key') || '';
+  const startDate = searchParams.get('startDate') || '';
+  const endDate = searchParams.get('endDate') || '';
+
+  if (!secret || !isValidSecret(secret)) return apiGuard();
+
+  const params = new URLSearchParams({ startDate, endDate });
+
+  const res = await fetch(`${apiUrl}/api/sismos/info/statistics?${params}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-ApiKey': DATA_API_KEY,
+    },
+  });
+
+  const stats = await res.json();
+
+  return Response.json(stats);
+}

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -92,13 +92,14 @@ interface EarthquakeEventJsonLdProps {
 
 export function EarthquakeEventJsonLd({ earthquake, url }: EarthquakeEventJsonLdProps) {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.sismosmx.app';
+  const pageId = url.split('/').pop() || '';
 
   const data = {
     '@context': 'https://schema.org',
     '@type': 'Event',
     name: `Sismo de magnitud ${earthquake.magnitude} en ${earthquake.state || 'México'}`,
     description: earthquake.details || `Sismo registrado con magnitud ${earthquake.magnitude}`,
-    startDate: earthquake.date,
+    startDate: earthquake.isoDate,
     eventStatus: 'https://schema.org/EventScheduled',
     eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
     location: {
@@ -131,7 +132,7 @@ export function EarthquakeEventJsonLd({ earthquake, url }: EarthquakeEventJsonLd
         value: earthquake.magnitude,
       },
     ],
-    image: `${siteUrl}/logo.svg`,
+    image: `${siteUrl}/api/og/earthquake/${pageId}`,
   };
 
   return <JsonLd data={data} />;

--- a/src/components/widgets/earthquakes-table/model.ts
+++ b/src/components/widgets/earthquakes-table/model.ts
@@ -7,4 +7,5 @@ export interface EarthquakeProps {
   date: string;
   time: string;
   details: string;
+  isoDate: string;
 }

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -10,6 +10,10 @@ export const navigation: NavItemProps[] = [
     href: '/sismos',
   },
   {
+    label: 'Estadísticas',
+    href: '/sismos/estadisticas',
+  },
+  {
     label: 'Acerca de',
     href: '/acerca-de',
   },

--- a/src/services/earthquakes/earthquakes.service.ts
+++ b/src/services/earthquakes/earthquakes.service.ts
@@ -17,6 +17,22 @@ export async function getEarthquakesData(limit: number = 10, page: number = 1) {
   }
 }
 
+export async function getStatistics(startDate: string, endDate: string) {
+  try {
+    const params = new URLSearchParams({ startDate, endDate });
+    const response = await fetch(
+      `${BASE_URL}/api/earthquakes/statistics?key=${process.env.SELF_SECRET}&${params}`,
+    );
+    const data = await response.json();
+
+    return data;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    return {};
+  }
+}
+
 export async function getEarthquakeDetail(id: string) {
   try {
     const response = await fetch(

--- a/src/services/earthquakes/helpers.ts
+++ b/src/services/earthquakes/helpers.ts
@@ -36,6 +36,7 @@ function parseEarthquake(earthquake: Record<string, unknown>): EarthquakeProps {
     date: earthquakeDate,
     time: formatAMPM(earthquakeDateTime),
     details: earthquake?.detalles as string,
+    isoDate: earthquakeDateTime.toISOString(),
   };
 }
 


### PR DESCRIPTION
## Summary
- **JSON-LD fix**: `startDate` now uses ISO 8601 (was Spanish formatted date), `image` now points to dynamic OG image (was logo.svg), added `isoDate` field to `EarthquakeProps`
- **Statistics page** (`/sismos/estadisticas`): Server-rendered page showing 30-day earthquake statistics — insights, summary cards, magnitude distribution, monthly breakdown
- **API route** (`/api/earthquakes/statistics`): Proxy to backend statistics endpoint, hidden from browser network inspector

## Changes
| File | Action |
|------|--------|
| `src/components/seo/JsonLd.tsx` | Fix `startDate` + `image` |
| `src/components/widgets/earthquakes-table/model.ts` | Add `isoDate` field |
| `src/services/earthquakes/helpers.ts` | Parse `isoDate` from `fecha` |
| `src/app/api/earthquakes/statistics/route.ts` | New API route proxy |
| `src/services/earthquakes/earthquakes.service.ts` | New `getStatistics()` |
| `src/app/(main)/sismos/estadisticas/page.tsx` | New statistics page |
| `src/config/navigation.ts` | Add nav link |

## Test plan
- [ ] Verify JSON-LD on detail page with Google Rich Results Test
- [ ] Open `/sismos/estadisticas` — verify stats render correctly
- [ ] Verify API call is NOT visible in browser network inspector
- [ ] Check navigation shows "Estadísticas" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)