### PR TITLE
feat: Add community report stats to earthquake detail pages (RFC-033)

### DIFF
--- a/src/app/(main)/sismos/detalle/[id]/page.tsx
+++ b/src/app/(main)/sismos/detalle/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import {
+  CommunityReportsSection,
   EarthquakeHeroSection,
   EarthquakesSection,
   SeeMoreSection,
@@ -7,7 +8,7 @@ import {
 } from '@/components/sections';
 import { StickyDownloadBar } from '@/components/widgets';
 import { BreadcrumbJsonLd, EarthquakeEventJsonLd } from '@/components/seo';
-import { getEarthquakeDetail, parseEarthquakes } from '@/services';
+import { getEarthquakeDetail, getReportStats, parseEarthquakes } from '@/services';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,7 +18,10 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
-  const response = await getEarthquakeDetail(id);
+  const [response, reportStats] = await Promise.all([
+    getEarthquakeDetail(id),
+    getReportStats(id),
+  ]);
   const earthquakes = parseEarthquakes([response?.data]);
   const earthquake = earthquakes[0];
 
@@ -33,7 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     : earthquake.state || 'México';
 
   const title = `Sismo de magnitud ${earthquake.magnitude} en ${location}`;
-  const description = `Sismo registrado el ${earthquake.date} a las ${earthquake.time} con magnitud ${earthquake.magnitude} en ${location}. ${earthquake.details || ''}`;
+
+  const reportsSuffix = reportStats && reportStats.totalReports > 0
+    ? ` ${reportStats.totalReports} personas reportaron este sismo.`
+    : '';
+  const description = `Sismo registrado el ${earthquake.date} a las ${earthquake.time} con magnitud ${earthquake.magnitude} en ${location}.${reportsSuffix} ${earthquake.details || ''}`;
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://sismosmx.app';
   const ogImageUrl = `${siteUrl}/api/og/earthquake/${id}`;
@@ -69,7 +77,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function EarthquakeDetailPage({ params }: Props) {
   const { id } = await params;
-  const response = await getEarthquakeDetail(id);
+  const [response, reportStats] = await Promise.all([
+    getEarthquakeDetail(id),
+    getReportStats(id),
+  ]);
   const detail = parseEarthquakes([response?.data]);
   const earthquake = detail[0];
 
@@ -87,6 +98,7 @@ export default async function EarthquakeDetailPage({ params }: Props) {
         <EarthquakeEventJsonLd
           earthquake={earthquake}
           url={`${siteUrl}/sismos/detalle/${id}`}
+          reportStats={reportStats}
         />
       )}
       <main>
@@ -94,6 +106,9 @@ export default async function EarthquakeDetailPage({ params }: Props) {
           <EarthquakeHeroSection earthquake={earthquake} />
         ) : null}
         <EarthquakesSection earthquakes={detail} mapTitle="Detalle del sismo" />
+        {reportStats && reportStats.totalReports > 0 && (
+          <CommunityReportsSection stats={reportStats} />
+        )}
         <SeeMoreSection
           title="¿Quieres enterarte de más sismos?"
           button={{

--- a/src/app/api/earthquakes/report-stats/route.ts
+++ b/src/app/api/earthquakes/report-stats/route.ts
@@ -1,0 +1,40 @@
+import { apiGuard, isValidSecret } from '@/utils';
+
+const DATA_API_KEY = process.env.DATA_API_KEY!;
+
+export async function GET(request: Request) {
+  const apiUrl = process.env.DATA_API_URL!;
+
+  const { searchParams } = new URL(request.url);
+  const secret = searchParams.get('key') || '';
+  const earthquakeToken = searchParams.get('token') || '';
+
+  if (!secret || !isValidSecret(secret)) return apiGuard();
+
+  if (!earthquakeToken) {
+    return Response.json({ data: null }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(
+      `${apiUrl}/api/sismos/info/reports/${earthquakeToken}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-ApiKey': DATA_API_KEY,
+        },
+        next: { revalidate: 300 }, // Cache 5 minutes
+      },
+    );
+
+    if (!res.ok) {
+      return Response.json({ data: null });
+    }
+
+    const stats = await res.json();
+
+    return Response.json({ data: stats });
+  } catch {
+    return Response.json({ data: null });
+  }
+}

--- a/src/app/api/earthquakes/statistics/route.ts
+++ b/src/app/api/earthquakes/statistics/route.ts
@@ -14,14 +14,32 @@ export async function GET(request: Request) {
 
   const params = new URLSearchParams({ startDate, endDate });
 
-  const res = await fetch(`${apiUrl}/api/sismos/info/statistics?${params}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-ApiKey': DATA_API_KEY,
-    },
-  });
+  try {
+    const url = `${apiUrl}/api/sismos/info/statistics?${params}`;
+    const res = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-ApiKey': DATA_API_KEY,
+      },
+    });
 
-  const stats = await res.json();
+    if (!res.ok) {
+      // eslint-disable-next-line no-console
+      console.error('[statistics] Backend error:', res.status);
+      return Response.json(
+        { success: false, data: null },
+        { status: res.status },
+      );
+    }
 
-  return Response.json(stats);
+    const stats = await res.json();
+    return Response.json(stats);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[statistics] Fetch error:', error);
+    return Response.json(
+      { success: false, data: null },
+      { status: 500 },
+    );
+  }
 }

--- a/src/components/sections/community-reports-section/CommunityReportsSection.tsx
+++ b/src/components/sections/community-reports-section/CommunityReportsSection.tsx
@@ -1,0 +1,163 @@
+import type { ReportStats } from '@/services';
+
+interface CommunityReportsSectionProps {
+  stats: ReportStats;
+}
+
+const INTENSITY_CONFIG = {
+  leve: { label: 'Leve', color: 'bg-yellow-400', textColor: 'text-yellow-700', bgLight: 'bg-yellow-50 dark:bg-yellow-900/20' },
+  moderado: { label: 'Moderado', color: 'bg-orange-400', textColor: 'text-orange-700', bgLight: 'bg-orange-50 dark:bg-orange-900/20' },
+  fuerte: { label: 'Fuerte', color: 'bg-red-500', textColor: 'text-red-700', bgLight: 'bg-red-50 dark:bg-red-900/20' },
+} as const;
+
+function IntensityBar({ breakdown }: { breakdown: ReportStats['intensityBreakdown'] }) {
+  const total = breakdown.leve + breakdown.moderado + breakdown.fuerte;
+  if (total === 0) return null;
+
+  const segments = [
+    { key: 'leve' as const, count: breakdown.leve },
+    { key: 'moderado' as const, count: breakdown.moderado },
+    { key: 'fuerte' as const, count: breakdown.fuerte },
+  ].filter((s) => s.count > 0);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex h-3 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+        {segments.map(({ key, count }) => (
+          <div
+            key={key}
+            className={`${INTENSITY_CONFIG[key].color} transition-all`}
+            style={{ width: `${(count / total) * 100}%` }}
+          />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-4">
+        {segments.map(({ key, count }) => {
+          const config = INTENSITY_CONFIG[key];
+          const pct = Math.round((count / total) * 100);
+          return (
+            <div key={key} className="flex items-center gap-2 text-sm">
+              <span className={`inline-block h-3 w-3 rounded-full ${config.color}`} />
+              <span className="text-gray-600 dark:text-gray-400">
+                {config.label}
+              </span>
+              <span className="font-semibold text-gray-900 dark:text-gray-100">
+                {`${count} (${pct}%)`}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMin / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffMin < 60) return `hace ${diffMin} min`;
+  if (diffHours < 24) return `hace ${diffHours}h`;
+  if (diffDays < 7) return `hace ${diffDays}d`;
+  return date.toLocaleDateString('es-MX', { day: 'numeric', month: 'short' });
+}
+
+function FeaturedComment({ report }: {
+  report: ReportStats['featuredReports'][0];
+}) {
+  const intensity = report.intensity.toLowerCase() as keyof typeof INTENSITY_CONFIG;
+  const config = INTENSITY_CONFIG[intensity] || INTENSITY_CONFIG.leve;
+
+  return (
+    <div className={`rounded-lg p-3 ${config.bgLight}`}>
+      <div className="mb-1 flex items-center justify-between">
+        <span className={`text-xs font-semibold uppercase ${config.textColor}`}>
+          {config.label}
+        </span>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {formatRelativeTime(report.reportedAt)}
+        </span>
+      </div>
+      {report.comment && (
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          &ldquo;
+          {report.comment}
+          &rdquo;
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function CommunityReportsSection({ stats }: CommunityReportsSectionProps) {
+  if (stats.totalReports === 0) return null;
+
+  const featuredWithComments = stats.featuredReports
+    .filter((r) => r.comment && r.comment.trim().length > 0)
+    .slice(0, 5);
+
+  return (
+    <section className="mx-auto w-full max-w-5xl px-4 py-8 md:py-12">
+      <div className="rounded-2xl border border-purple-200 bg-purple-50/50 p-6 dark:border-purple-800 dark:bg-purple-950/30 md:p-8">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-100 dark:bg-purple-900">
+            <svg
+              className="h-5 w-5 text-purple-600 dark:text-purple-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 md:text-xl">
+              Reportes de la Comunidad
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              <span className="font-bold text-purple-600 dark:text-purple-400">
+                {stats.totalReports}
+              </span>
+              {' '}
+              {stats.totalReports === 1 ? 'persona report\u00f3' : 'personas reportaron'}
+              {' '}
+              este sismo
+            </p>
+          </div>
+        </div>
+
+        <IntensityBar breakdown={stats.intensityBreakdown} />
+
+        {featuredWithComments.length > 0 && (
+          <div className="mt-6 space-y-3">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              Comentarios destacados
+            </h3>
+            {featuredWithComments.map((report, i) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <FeaturedComment key={i} report={report} />
+            ))}
+          </div>
+        )}
+
+        <div className="mt-6 rounded-lg bg-purple-100 p-4 text-center dark:bg-purple-900/40">
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            ¿Sentiste este sismo?
+          </p>
+          <p className="font-semibold text-purple-700 dark:text-purple-300">
+            Descarga Sismos MX y reporta
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -9,3 +9,4 @@ export * from './legal-notice-section/content';
 export * from './ritcher-scale-section/RitcherScaleSection';
 export * from './earthquakes-section/EarthquakesSection';
 export * from './earthquake-hero-section/EarthquakeHeroSection';
+export * from './community-reports-section/CommunityReportsSection';

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -1,4 +1,5 @@
 import { EarthquakeProps } from '@/components/widgets';
+import { ReportStats } from '@/services';
 
 interface JsonLdProps {
   data: Record<string, unknown>;
@@ -88,13 +89,49 @@ export function BreadcrumbJsonLd({ items }: BreadcrumbJsonLdProps) {
 interface EarthquakeEventJsonLdProps {
   earthquake: EarthquakeProps;
   url: string;
+  reportStats?: ReportStats | null;
 }
 
-export function EarthquakeEventJsonLd({ earthquake, url }: EarthquakeEventJsonLdProps) {
+export function EarthquakeEventJsonLd({
+  earthquake, url, reportStats,
+}: EarthquakeEventJsonLdProps) {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.sismosmx.app';
   const pageId = url.split('/').pop() || '';
 
-  const data = {
+  const additionalProperties: Record<string, unknown>[] = [
+    {
+      '@type': 'PropertyValue',
+      name: 'Magnitud',
+      value: earthquake.magnitude,
+    },
+  ];
+
+  if (reportStats && reportStats.totalReports > 0) {
+    additionalProperties.push(
+      {
+        '@type': 'PropertyValue',
+        name: 'Reportes comunitarios',
+        value: reportStats.totalReports,
+      },
+      {
+        '@type': 'PropertyValue',
+        name: 'Intensidad leve',
+        value: reportStats.intensityBreakdown.leve,
+      },
+      {
+        '@type': 'PropertyValue',
+        name: 'Intensidad moderada',
+        value: reportStats.intensityBreakdown.moderado,
+      },
+      {
+        '@type': 'PropertyValue',
+        name: 'Intensidad fuerte',
+        value: reportStats.intensityBreakdown.fuerte,
+      },
+    );
+  }
+
+  const data: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'Event',
     name: `Sismo de magnitud ${earthquake.magnitude} en ${earthquake.state || 'México'}`,
@@ -125,13 +162,7 @@ export function EarthquakeEventJsonLd({ earthquake, url }: EarthquakeEventJsonLd
     },
     url,
     isAccessibleForFree: true,
-    additionalProperty: [
-      {
-        '@type': 'PropertyValue',
-        name: 'Magnitud',
-        value: earthquake.magnitude,
-      },
-    ],
+    additionalProperty: additionalProperties,
     image: `${siteUrl}/api/og/earthquake/${pageId}`,
   };
 

--- a/src/services/earthquakes/earthquakes.service.ts
+++ b/src/services/earthquakes/earthquakes.service.ts
@@ -17,18 +17,27 @@ export async function getEarthquakesData(limit: number = 10, page: number = 1) {
   }
 }
 
-export async function getStatistics(startDate: string, endDate: string) {
+export async function getStatistics(
+  startDate: string,
+  endDate: string,
+) {
   try {
     const params = new URLSearchParams({ startDate, endDate });
-    const response = await fetch(
-      `${BASE_URL}/api/earthquakes/statistics?key=${process.env.SELF_SECRET}&${params}`,
-    );
-    const data = await response.json();
+    const url = `${BASE_URL}/api/earthquakes/statistics`
+      + `?key=${process.env.SELF_SECRET}&${params}`;
+    const response = await fetch(url);
 
+    if (!response.ok) {
+      // eslint-disable-next-line no-console
+      console.error('[getStatistics] HTTP', response.status);
+      return {};
+    }
+
+    const data = await response.json();
     return data;
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error(error);
+    console.error('[getStatistics] Error:', error);
     return {};
   }
 }
@@ -45,5 +54,37 @@ export async function getEarthquakeDetail(id: string) {
     // eslint-disable-next-line no-console
     console.error(error);
     return {};
+  }
+}
+
+export interface ReportStats {
+  earthquakeToken: string;
+  totalReports: number;
+  intensityBreakdown: {
+    leve: number;
+    moderado: number;
+    fuerte: number;
+  };
+  featuredReports: {
+    intensity: string;
+    comment: string | null;
+    reportedAt: string;
+  }[];
+}
+
+export async function getReportStats(
+  earthquakeToken: string,
+): Promise<ReportStats | null> {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/api/earthquakes/report-stats?key=${process.env.SELF_SECRET}&token=${earthquakeToken}`,
+    );
+    const json = await response.json();
+
+    return json?.data ?? null;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[getReportStats] Error:', error);
+    return null;
   }
 }


### PR DESCRIPTION
Enrich earthquake detail landing pages with community report data for SEO:
- API route proxy for report-stats endpoint with 5-min cache
- getReportStats server function + ReportStats interface
- CommunityReportsSection component (intensity bar, featured comments, dark mode)
- Enriched Open Graph metadata with report count in description
- Enriched JSON-LD additionalProperty with intensity breakdown
- Hardened statistics route with try/catch error handling