### PR TITLE
feat: drill-aware OG metadata and copy on /event/[id] (RFC-033)

### DIFF
--- a/src/app/event/[id]/EarthquakeStoryCard.tsx
+++ b/src/app/event/[id]/EarthquakeStoryCard.tsx
@@ -29,7 +29,12 @@ interface Props {
 
 function StoryCardContent({ event, heroEta, mapUrl }: Props) {
   const searchParams = useSearchParams();
-  const isFromPush = searchParams.get('ref') === 'push';
+  const ref = searchParams.get('ref');
+  // RFC-033: drill_close pushes also count as "from push" — they go through
+  // the same OneSignal story-push pipeline, only the ref tag differs so we
+  // can split analytics later.
+  const isFromPush = ref === 'push' || ref === 'drill_close';
+  const isDrill = event.eventType === 'drill' || event.eventType === 'drill_staging';
   const storeUrl = useStoreUrl();
   const reviewUrl = useReviewUrl();
 
@@ -44,9 +49,14 @@ function StoryCardContent({ event, heroEta, mapUrl }: Props) {
   const shareUrl = typeof window !== 'undefined'
     ? window.location.origin + window.location.pathname
     : '';
-  const shareText = heroEta
-    ? `Recibi alerta sismica ${heroEta}s antes del sismo ${event.intensity} en ${event.location}`
-    : `Sismo ${event.intensity} en ${event.location}`;
+  let shareText: string;
+  if (isDrill) {
+    shareText = 'Participé en el simulacro nacional con Sismos MX';
+  } else if (heroEta) {
+    shareText = `Recibi alerta sismica ${heroEta}s antes del sismo ${event.intensity} en ${event.location}`;
+  } else {
+    shareText = `Sismo ${event.intensity} en ${event.location}`;
+  }
 
   const handleShare = async () => {
     if (navigator.share) {
@@ -93,8 +103,16 @@ function StoryCardContent({ event, heroEta, mapUrl }: Props) {
 
         {/* Earthquake info */}
         <div className={`text-center ${heroEta ? 'mt-8' : 'mt-0'}`}>
+          {isDrill && (
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-yellow-400/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-yellow-300 ring-1 ring-yellow-400/30">
+              <span aria-hidden="true">{'\uD83C\uDFAF'}</span>
+              Simulacro nacional
+            </div>
+          )}
           <h1 className="text-3xl font-bold md:text-4xl">
-            {`Sismo ${event.intensity} \u2014 ${event.location}`}
+            {isDrill
+              ? `Simulacro nacional \u2014 ${event.location}`
+              : `Sismo ${event.intensity} \u2014 ${event.location}`}
           </h1>
           <p className="mt-2 text-lg text-white/50">{dateFormatted}</p>
         </div>
@@ -111,9 +129,24 @@ function StoryCardContent({ event, heroEta, mapUrl }: Props) {
           </div>
         )}
 
-        {/* Narrative — contextual by audience */}
+        {/* Narrative — contextual by audience and event type */}
         <div className="mt-10 max-w-md text-center">
-          {isFromPush ? (
+          {isDrill && isFromPush && (
+            <>
+              <p className="text-base leading-relaxed text-white/50">
+                Practicaste el simulacro nacional 2026.
+              </p>
+              <p className="mt-3 text-base leading-relaxed text-white/70">
+                {'Comparte tu participaci\u00F3n para que m\u00E1s personas est\u00E9n preparadas en el pr\u00F3ximo sismo.'}
+              </p>
+            </>
+          )}
+          {isDrill && !isFromPush && (
+            <p className="text-base leading-relaxed text-white/70">
+              {'Esto fue parte del simulacro nacional 2026. Descarga Sismos MX para participar la pr\u00F3xima vez.'}
+            </p>
+          )}
+          {!isDrill && isFromPush && (
             <>
               {heroEta && (
                 <p className="text-base leading-relaxed text-white/50">
@@ -124,7 +157,8 @@ function StoryCardContent({ event, heroEta, mapUrl }: Props) {
                 {'Comparte con tu familia y amigos para que tambi\u00E9n est\u00E9n prevenidos en el pr\u00F3ximo sismo.'}
               </p>
             </>
-          ) : (
+          )}
+          {!isDrill && !isFromPush && (
             <>
               {heroEta && (
                 <p className="text-base leading-relaxed text-white/50">
@@ -140,23 +174,28 @@ function StoryCardContent({ event, heroEta, mapUrl }: Props) {
 
         {/* CTAs */}
         <div className="mt-10 flex w-full max-w-sm flex-col gap-3">
-          {isFromPush ? (
+          {isFromPush && (
             <>
               <button
                 type="button"
                 onClick={handleShare}
                 className="rounded-xl bg-yellow-400 py-4 text-center text-lg font-bold text-black shadow-[0_0_20px_rgba(250,204,21,0.2)] transition-shadow hover:shadow-[0_0_30px_rgba(250,204,21,0.35)]"
               >
-                Invitar a familia y amigos
+                {isDrill ? 'Comparte tu simulacro' : 'Invitar a familia y amigos'}
               </button>
-              <a
-                href={reviewUrl}
-                className="rounded-xl bg-white/10 py-4 text-center text-lg font-bold text-white"
-              >
-                {'\u00BFTe ayud\u00F3 la alerta? Calif\u00EDcanos'}
-              </a>
+              {/* Suppress the app-review CTA for drills — asking for a rating
+                  after a simulacro doesn't fit the moment. */}
+              {!isDrill && (
+                <a
+                  href={reviewUrl}
+                  className="rounded-xl bg-white/10 py-4 text-center text-lg font-bold text-white"
+                >
+                  {'\u00BFTe ayud\u00F3 la alerta? Calif\u00EDcanos'}
+                </a>
+              )}
             </>
-          ) : (
+          )}
+          {!isFromPush && (
             <>
               <a
                 href={storeUrl}

--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -10,6 +10,16 @@ type Props = {
 const INTENSITY_ORDER = ['Extremo', 'MuyViolento', 'Violento', 'Fuerte', 'Moderado'];
 
 /**
+ * RFC-033: a drill share URL must surface drill-flavored OG metadata so
+ * recipients on WhatsApp / Twitter see "Completé el simulacro nacional"
+ * instead of "Sismo Fuerte" — even though the URL pattern is identical
+ * to a real-event share.
+ */
+function isDrillEvent(eventType?: string): boolean {
+  return eventType === 'drill' || eventType === 'drill_staging';
+}
+
+/**
  * Hero stat: best available anticipation metric.
  * 1. City with highest intensity that has ETA > 0
  * 2. Any city with smallest ETA > 0
@@ -46,13 +56,23 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const event = await getEarthquakeEvent(id);
   if (!event) return { title: 'Sismo no encontrado' };
 
+  const isDrill = isDrillEvent(event.eventType);
   const heroEta = getHeroEta(event);
-  const title = heroEta
-    ? `${heroEta}s de anticipacion — Sismo ${event.intensity} en ${event.location}`
-    : `Sismo ${event.intensity} en ${event.location}`;
-  const description = heroEta
-    ? `Sismos MX envio la alerta ${heroEta} segundos antes. Descarga la app.`
-    : `Sismo ${event.intensity} en ${event.location}. Descarga Sismos MX.`;
+  let title: string;
+  let description: string;
+  if (isDrill) {
+    // Drill share: reframe around participation. Same URL serves both real
+    // and drill events; only the OG payload changes.
+    title = 'Completé el simulacro nacional con Sismos MX';
+    description = 'Practiqué el simulacro nacional 2026. '
+      + 'Descarga Sismos MX para participar la próxima vez.';
+  } else if (heroEta) {
+    title = `${heroEta}s de anticipacion — Sismo ${event.intensity} en ${event.location}`;
+    description = `Sismos MX envio la alerta ${heroEta} segundos antes. Descarga la app.`;
+  } else {
+    title = `Sismo ${event.intensity} en ${event.location}`;
+    description = `Sismo ${event.intensity} en ${event.location}. Descarga Sismos MX.`;
+  }
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://sismosmx.app';
   const ogImageUrl = `${siteUrl}/api/og/event/${id}`;

--- a/src/services/earthquakes/earthquakes.service.ts
+++ b/src/services/earthquakes/earthquakes.service.ts
@@ -112,6 +112,17 @@ export interface CityEta {
 
 export interface EarthquakeEventResponse {
   collapseKey: string;
+  /**
+   * RFC-033 discriminator. `real` (default) for genuine seismic events,
+   * `drill` for the national simulacro, `drill_staging` for QA. The web
+   * branches OG metadata + body copy off this — the URL pattern stays
+   * the same between real and drill so a single shared link works for
+   * both.
+   *
+   * Optional in the type because pre-RFC-033 backends omitted it; the
+   * page treats anything not strictly `drill` / `drill_staging` as real.
+   */
+  eventType?: string;
   intensity: string;
   location: string;
   epicenterLat?: number;


### PR DESCRIPTION
## Summary
Reads the new `event_type` field from the snapshot `EarthquakeEventResponse` (added in MonitorAlertsApi PR #183) and branches the story page presentation between real and drill events. **Same URL pattern** (`sismosmx.app/event/{collapseKey}`) serves both — only the rendered metadata and body copy change.

## What changes for drill events
- **OG title:** \"Completé el simulacro nacional con Sismos MX\"
- **OG description:** reframes around participation, not anticipation seconds
- **Page header:** \"Simulacro nacional — {location}\" + yellow pill badge with target emoji
- **Narrative (from push):** \"Practicaste el simulacro nacional 2026\" instead of the \"tu alerta llegó N segundos antes\" framing
- **Narrative (direct link):** \"Esto fue parte del simulacro nacional 2026. Descarga Sismos MX para participar la próxima vez.\"
- **Primary CTA:** \"Comparte tu simulacro\" instead of \"Invitar a familia y amigos\"
- **Suppresses the app-review CTA** — asking for a rating after a drill doesn't fit the moment
- **Share text:** \"Participé en el simulacro nacional con Sismos MX\"

## ?ref=drill_close support
Also accepts `?ref=drill_close` as a \"from push\" marker — drill share pushes use that ref tag (RFC-033 backend, PR #180) so analytics can split drill-close opens from real-event story opens.

## Backward compat
Default to \"real\" treatment when `event_type` is absent or unknown — preserves behavior for legacy events stored before RFC-033 + protects against future variants the web doesn't know about (worst-case shows real copy for an unknown drill subtype, vs the dangerous opposite of showing drill copy for a real event).

## Files
- `src/services/earthquakes/earthquakes.service.ts` — adds `eventType?: string` to `EarthquakeEventResponse`
- `src/app/event/[id]/page.tsx` — drill branch in `generateMetadata` + helper `isDrillEvent`
- `src/app/event/[id]/EarthquakeStoryCard.tsx` — badge, title, narrative, CTA, share text branching

## Dependencies
- Backend PR #183 (MonitorAlertsApi) — adds `event_type` to snapshot endpoint
- Backend PR #178 (merged) — RFC-033 base implementation

## Test plan
- [ ] CI green (lint + build)
- [ ] Manual smoke once backend PR #183 merges + deploys:
  - [ ] Visit `/event/{realEventId}` → renders \"Sismo X en Y\", \"Invitar a familia\" CTA, app-review CTA visible
  - [ ] Visit `/event/{drillEventId}` → renders \"Simulacro nacional\" pill, drill copy, \"Comparte tu simulacro\" CTA, NO app-review CTA
  - [ ] Visit `/event/{drillEventId}?ref=drill_close` → drill copy + \"from push\" narrative
  - [ ] OG preview tools (e.g. opengraph.xyz) show drill title + description for drill events

## Out of scope
- Drill-specific OG image (the existing `/api/og/event/[id]` route still renders the generic earthquake card). Can be a follow-up — body copy + OG title carry the bulk of the messaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)