### PR TITLE
Fix earthquake time formatting in Mexico City timezone

### DIFF
--- a/src/app/(main)/sismos/hoy/page.tsx
+++ b/src/app/(main)/sismos/hoy/page.tsx
@@ -6,12 +6,15 @@ import {
 } from '@/components/sections';
 import { BreadcrumbJsonLd, EarthquakesListJsonLd } from '@/components/seo';
 import { getEarthquakesData, parseEarthquakes } from '@/services';
+import {
+  formatDateInMexicoCity,
+  getCurrentMexicoCityDate,
+} from '@/utils/dateTime.utility';
 
 export const dynamic = 'force-dynamic';
 
 function formatDateForTitle(dateString: string): string {
-  const date = new Date(dateString);
-  return date.toLocaleDateString('es-MX', {
+  return formatDateInMexicoCity(dateString, {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
@@ -19,8 +22,7 @@ function formatDateForTitle(dateString: string): string {
 }
 
 function formatDateForSEO(dateString: string): string {
-  const date = new Date(dateString);
-  return date.toLocaleDateString('es-MX', {
+  return formatDateInMexicoCity(dateString, {
     weekday: 'long',
     day: 'numeric',
     month: 'long',
@@ -29,7 +31,7 @@ function formatDateForSEO(dateString: string): string {
 }
 
 function getDefaultFormattedDate(): string {
-  return new Date().toLocaleDateString('es-MX', {
+  return getCurrentMexicoCityDate({
     day: 'numeric',
     month: 'long',
     year: 'numeric',

--- a/src/app/api/og/earthquake/[token]/route.tsx
+++ b/src/app/api/og/earthquake/[token]/route.tsx
@@ -1,5 +1,9 @@
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from 'next/og';
+import {
+  formatDateInMexicoCity,
+  formatTimeInMexicoCity,
+} from '@/utils/dateTime.utility';
 
 export const runtime = 'edge';
 
@@ -23,19 +27,12 @@ function parseLocation(detalles: string): { town: string; state: string } {
 }
 
 function formatDate(fecha: string): { date: string; time: string } {
-  const dt = new Date(fecha);
-  const date = dt.toLocaleDateString('es-MX', {
+  const date = formatDateInMexicoCity(fecha, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   });
-  let hours = dt.getHours();
-  let minutes: number | string = dt.getMinutes();
-  const ampm = hours >= 12 ? 'pm' : 'am';
-  hours %= 12;
-  hours = hours || 12;
-  minutes = minutes < 10 ? `0${minutes}` : minutes;
-  return { date, time: `${hours}:${minutes} ${ampm}` };
+  return { date, time: formatTimeInMexicoCity(fecha) };
 }
 
 export async function GET(

--- a/src/app/api/og/event/[id]/route.tsx
+++ b/src/app/api/og/event/[id]/route.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from 'next/og';
+import { formatDateTimeInMexicoCity } from '@/utils/dateTime.utility';
 
 export const runtime = 'edge';
 
@@ -98,12 +99,10 @@ export async function GET(
   if (!event) return fallbackImage();
 
   const heroEta = getHeroEta(event);
-  const dateFormatted = new Date(event.dateUtc).toLocaleDateString('es-MX', {
+  const dateFormatted = formatDateTimeInMexicoCity(event.dateUtc, {
     day: 'numeric',
     month: 'short',
     year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
   });
 
   const hasCoords = event.epicenterLat != null && event.epicenterLng != null;

--- a/src/app/event/[id]/EarthquakeStoryCard.tsx
+++ b/src/app/event/[id]/EarthquakeStoryCard.tsx
@@ -3,7 +3,7 @@
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useState } from 'react';
 import { EarthquakeEventResponse } from '@/services';
-import { useStoreUrl } from '@/utils';
+import { formatDateTimeInMexicoCity, useStoreUrl } from '@/utils';
 
 const IOS_REVIEW_URL = 'https://apps.apple.com/app/id6473684021?action=write-review';
 const ANDROID_REVIEW_URL = 'https://play.google.com/store/apps/details?id=com.oscar.sismos_v2';
@@ -38,12 +38,10 @@ function StoryCardContent({ event, heroEta, mapUrl }: Props) {
   const storeUrl = useStoreUrl();
   const reviewUrl = useReviewUrl();
 
-  const dateFormatted = new Date(event.dateUtc).toLocaleDateString('es-MX', {
+  const dateFormatted = formatDateTimeInMexicoCity(event.dateUtc, {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
   });
 
   const shareUrl = typeof window !== 'undefined'

--- a/src/services/earthquakes/helpers.ts
+++ b/src/services/earthquakes/helpers.ts
@@ -1,22 +1,13 @@
 import { EarthquakeProps } from '@/components/widgets';
-
-function formatAMPM(date: Date) {
-  let hours = date.getHours();
-  let minutes: number | string = date.getMinutes();
-  const ampm = hours >= 12 ? 'pm' : 'am';
-
-  hours %= 12;
-  hours = hours || 12; // the hour '0' should be '12'
-  minutes = minutes < 10 ? `0${minutes}` : minutes;
-
-  const strTime = `${hours}:${minutes} ${ampm}`;
-  return strTime;
-}
+import {
+  formatDateInMexicoCity,
+  formatTimeInMexicoCity,
+} from '@/utils/dateTime.utility';
 
 // Parsers
 function parseEarthquake(earthquake: Record<string, unknown>): EarthquakeProps {
-  const earthquakeDateTime = new Date(earthquake?.fecha as string);
-  const earthquakeDate = earthquakeDateTime.toLocaleDateString('es-MX', {
+  const earthquakeDateTime = earthquake?.fecha as string;
+  const earthquakeDate = formatDateInMexicoCity(earthquakeDateTime, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -34,9 +25,9 @@ function parseEarthquake(earthquake: Record<string, unknown>): EarthquakeProps {
     lat: parseFloat(earthquake?.laltitud as string),
     lng: parseFloat(earthquake?.longitud as string),
     date: earthquakeDate,
-    time: formatAMPM(earthquakeDateTime),
+    time: formatTimeInMexicoCity(earthquakeDateTime),
     details: earthquake?.detalles as string,
-    isoDate: earthquakeDateTime.toISOString(),
+    isoDate: new Date(earthquakeDateTime).toISOString(),
   };
 }
 

--- a/src/utils/dateTime.utility.ts
+++ b/src/utils/dateTime.utility.ts
@@ -1,0 +1,49 @@
+const MEXICO_CITY_TIME_ZONE = 'America/Mexico_City';
+
+function getDate(value: string | Date): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+export function formatDateInMexicoCity(
+  value: string | Date,
+  options: Intl.DateTimeFormatOptions = {},
+): string {
+  return new Intl.DateTimeFormat('es-MX', {
+    timeZone: MEXICO_CITY_TIME_ZONE,
+    ...options,
+  }).format(getDate(value));
+}
+
+export function formatTimeInMexicoCity(value: string | Date): string {
+  const parts = new Intl.DateTimeFormat('es-MX', {
+    timeZone: MEXICO_CITY_TIME_ZONE,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).formatToParts(getDate(value));
+
+  const hour = parts.find((part) => part.type === 'hour')?.value ?? '';
+  const minute = parts.find((part) => part.type === 'minute')?.value ?? '';
+  const dayPeriod = (parts.find((part) => part.type === 'dayPeriod')?.value ?? '')
+    .replace(/\./g, '')
+    .toLowerCase();
+
+  return `${hour}:${minute} ${dayPeriod}`.trim();
+}
+
+export function formatDateTimeInMexicoCity(
+  value: string | Date,
+  dateOptions: Intl.DateTimeFormatOptions = {},
+): string {
+  const date = formatDateInMexicoCity(value, dateOptions);
+  const time = formatTimeInMexicoCity(value);
+  return `${date} ${time}`.trim();
+}
+
+export function getCurrentMexicoCityDate(
+  options: Intl.DateTimeFormatOptions = {},
+): string {
+  return formatDateInMexicoCity(new Date(), options);
+}
+
+export { MEXICO_CITY_TIME_ZONE };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './api-guard.utility';
 export * from './className.utility';
+export * from './dateTime.utility';
 export * from './useStoreUrl';


### PR DESCRIPTION
## Summary
- centralize earthquake date/time formatting in a Mexico City timezone utility
- use explicit `America/Mexico_City` formatting in earthquake list parsing, `/sismos/hoy`, event story UI, and OG image routes
- remove implicit runtime-dependent `new Date(...)/getHours()` formatting for seismic timestamps

## Validation
- `npm run lint`
- verified the original example `2026-04-21T14:52:14Z` formats as `8:52 am` in Mexico City and no longer depends on the server timezone

## Notes
- PR base is `feat/drill-event-type-og-metadata` to keep this fix isolated from that feature branch's existing commit history.