### PR TITLE
feat(event-page): Premium CTA card with web_event_cta tracking

### DIFF
--- a/src/app/event/[id]/EarthquakeStoryCard.tsx
+++ b/src/app/event/[id]/EarthquakeStoryCard.tsx
@@ -1,12 +1,15 @@
 'use client';
 
+import { track } from '@vercel/analytics';
 import { useSearchParams } from 'next/navigation';
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import { EarthquakeEventResponse } from '@/services';
 import { formatDateTimeInMexicoCity, useStoreUrl } from '@/utils';
 
 const IOS_REVIEW_URL = 'https://apps.apple.com/app/id6473684021?action=write-review';
 const ANDROID_REVIEW_URL = 'https://play.google.com/store/apps/details?id=com.oscar.sismos_v2';
+
+const WEB_EVENT_CTA_SOURCE = 'web_event_page';
 
 function useReviewUrl(): string {
   const [reviewUrl, setReviewUrl] = useState(IOS_REVIEW_URL);
@@ -25,6 +28,65 @@ interface Props {
   event: EarthquakeEventResponse;
   heroEta: number | null;
   mapUrl: string | null;
+}
+
+interface PremiumCtaCardProps {
+  eventId: string;
+  isDrill: boolean;
+}
+
+function PremiumCtaCard({ eventId, isDrill }: PremiumCtaCardProps) {
+  const storeUrl = useStoreUrl();
+  const loggedImpression = useRef(false);
+
+  useEffect(() => {
+    if (loggedImpression.current) return;
+    loggedImpression.current = true;
+    track('web_event_cta_shown', {
+      source: WEB_EVENT_CTA_SOURCE,
+      event_id: eventId,
+      event_type: isDrill ? 'drill' : 'real',
+    });
+  }, [eventId, isDrill]);
+
+  const handleClick = () => {
+    track('web_event_cta_tapped', {
+      source: WEB_EVENT_CTA_SOURCE,
+      event_id: eventId,
+      event_type: isDrill ? 'drill' : 'real',
+    });
+  };
+
+  const target = new URL(storeUrl);
+  target.searchParams.set('utm_source', WEB_EVENT_CTA_SOURCE);
+  target.searchParams.set('utm_medium', 'premium_cta');
+  target.searchParams.set('utm_campaign', `event_${eventId}`);
+
+  return (
+    <a
+      href={target.toString()}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={handleClick}
+      className="rounded-2xl border border-yellow-400/20 bg-gradient-to-br from-yellow-400/10 to-white/[0.04] p-5 text-left backdrop-blur-sm"
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-2xl" aria-hidden="true">🏠</span>
+        <div className="flex-1">
+          <p className="text-lg font-bold leading-tight text-white">
+            Sabe cuándo llega a tu casa
+          </p>
+          <p className="mt-1 text-sm leading-snug text-white/60">
+            Premium te avisa los segundos antes en tu casa, oficina y la escuela.
+          </p>
+          <p className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-yellow-300">
+            <span>Activar Premium</span>
+            <span aria-hidden="true">→</span>
+          </p>
+        </div>
+      </div>
+    </a>
+  );
 }
 
 function StoryCardContent({ event, heroEta, mapUrl }: Props) {
@@ -172,6 +234,9 @@ function StoryCardContent({ event, heroEta, mapUrl }: Props) {
 
         {/* CTAs */}
         <div className="mt-10 flex w-full max-w-sm flex-col gap-3">
+          {!isDrill && (
+            <PremiumCtaCard eventId={event.collapseKey} isDrill={isDrill} />
+          )}
           {isFromPush && (
             <>
               <button


### PR DESCRIPTION
## Summary

Adds a Premium pitch to `/event/[id]` pages targeting the warm visits we currently lose to zero monetization path.

- Card copy mirrors the in-app banner that already converts: **"Sabe cuándo llega a tu casa"** + the family-safety subtitle.
- Shown for **real events only** — suppressed on drills.
- Position: top of the existing CTA stack, in both `isFromPush=true` and `isFromPush=false` branches.
- Fires `web_event_cta_shown` once per mount and `web_event_cta_tapped` on click via Vercel Analytics. Both carry `source=web_event_page`, `event_id`, `event_type`.
- Links to the platform store URL with UTM params (`web_event_page` / `premium_cta` / `event_<id>`). When the Flutter deep link handler ships in the next release we swap to a universal link that routes to the in-app paywall with `source=web_event_page`.

## Why this is high-leverage

Sismos MX `/event/*` pages get ~300 visits per significant event × ~12 significant events/mo ≈ 3,000–4,000 warm visits/mo with **0% conversion path** today. Anything > 1% CTR on this card is net-new monetization volume.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Manual: confirm card renders for real event + `isFromPush=true`
- [x] Manual: confirm card renders for real event + `isFromPush=false`
- [x] Manual: confirm card is suppressed for `event.eventType === 'drill'`

## Out of scope

- Universal-link variant (waits for Flutter `source=web_event_page` deep link handler in next release).
- A/B test of copy / placement (ship one variant, instrument, iterate after first 2 weeks of data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)