### PR TITLE
feat(applinks): add /premium to apple-app-site-association

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -4,7 +4,7 @@
     "details": [
       {
         "appID": "7GZ754TPZQ.com.oscar.sismosv2",
-        "paths": ["/join/*", "/invite/*", "/sismos/detalle/*"]
+        "paths": ["/join/*", "/invite/*", "/sismos/detalle/*", "/premium", "/premium?*"]
       }
     ]
   }


### PR DESCRIPTION
## Summary

iOS Universal Links allowlist requires the path explicitly. Android is already covered by \`assetlinks.json\`'s \`handle_all_urls\`.

Pairs with the Flutter side that parses the route → opens paywall ([earthquakesFlutter PR #275](https://github.com/SOSMex/earthquakesFlutter/pull/275)).

## Patterns added

\`\`\`
/premium
/premium?*
\`\`\`

Two entries so iOS recognizes the universal link both with and without query params (the real-world link looks like \`https://sismosmx.app/premium?source=web_event_page&event_id=eq_123\`).

## Test plan

- [x] JSON still valid (single-line edit, syntax preserved)
- [ ] Post-deploy: verify with \`curl -I https://sismosmx.app/.well-known/apple-app-site-association\` returns 200 and \`Content-Type: application/json\`
- [ ] Apple AASA Validator: https://branch.io/resources/aasa-validator/

🤖 Generated with [Claude Code](https://claude.com/claude-code)